### PR TITLE
fix stats (#3)

### DIFF
--- a/libs/stats.js
+++ b/libs/stats.js
@@ -114,7 +114,7 @@ module.exports = function(logger, portalConfig, poolConfigs){
                 ['hgetall', ':stats'],
                 ['scard', ':blocksPending'],
                 ['scard', ':blocksConfirmed'],
-                ['scard', ':blocksOrphaned']
+                ['scard', ':blocksKicked']
             ];
 
             var commandsPerCoin = redisCommandTemplates.length;


### PR DESCRIPTION
orphaned block appear in redis as 'blocksKicked', not 'blocksOrphaned'